### PR TITLE
Added mapping for is_valid of BankAccount

### DIFF
--- a/src/main/java/com/balancedpayments/BankAccount.java
+++ b/src/main/java/com/balancedpayments/BankAccount.java
@@ -17,6 +17,9 @@ public class BankAccount extends Resource {
     @ResourceField(mutable=true)
     public String name;
 
+    @ResourceField()
+    public Boolean is_valid;
+
     @ResourceField(mutable=true)
     public String account_number;
 


### PR DESCRIPTION
Deleted bank accounts are retrievable, and it appears I need this field in order to distinguish deleted bank accounts from non-deleted ones.

Fixes #22 
