### PR TITLE
Added <scope> where missing to eliminated crazy inherited dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,16 +49,19 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient-osgi</artifactId>
             <version>4.2.1</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.1</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
             <version>1.7</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -70,11 +73,13 @@
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>cobertura-maven-plugin</artifactId>
             <version>2.6</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>2.2.3</version>
+            <scope>test</scope>
         </dependency>
         <!--
         <dependency>


### PR DESCRIPTION
Added <scope> where missing, which was causing crazy inherited dependencies.  Particularly with Cobertura getting sucked in -- which is a Maven plugin, and came with a ton of Maven plugin dependencies, etc. etc.
